### PR TITLE
Put jsdom as a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
     "url": "https://github.com/rstacruz/jsdom-global/issues"
   },
   "homepage": "https://github.com/rstacruz/jsdom-global#readme",
+  "dependencies": {
+    "jsdom": "7.2.2"
+  },
   "devDependencies": {
-    "jsdom": "7.2.2",
     "tape": "4.4.0"
   }
 }


### PR DESCRIPTION
Hey,

I think that was a typo adding `jsdom` in `devDependencies`. So I moved it to `dependencies` to avoid users to install it as a peer dependency.
