### PR TITLE
pass the options to jsdom

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ npm install --save-dev --save-exact jsdom jsdom-global
 Just invoke it to turn your Node.js environment into a DOM environment.
 
 ```js
-require('jsdom-global')()
+require('jsdom-global')(html, options)
 
 // you can now use the DOM
 document.body.innerHTML = 'hello'
 ```
+
+Both `html` and `options` parameters are optional.
+Check the [jsdom.jsdom()][] documentation for valid values for the `options` parameter.
 
 To clean up after itself, just invoke the function it returns.
 
@@ -71,6 +74,7 @@ after(function () {
 
 [tape]: https://github.com/substack/tape
 [mocha]: https://mochajs.org/
+[jsdom.jsdom()]: https://github.com/tmpvar/jsdom/#for-the-hardcore-jsdomjsdom
 
 ## Browserify
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
  * enables jsdom globally.
  */
 
-var html = '<!doctype html><html><head><meta charset="utf-8">' +
+var defaultHtml = '<!doctype html><html><head><meta charset="utf-8">' +
   '</head><body></body></html>'
 
 var blacklist = [
@@ -11,20 +11,15 @@ var blacklist = [
   'Float64Array', 'toString', 'constructor', 'console', 'setTimeout',
   'clearTimeout', 'setInterval', 'clearInterval' ]
 
-module.exports = function globalJsdom (func) {
-  if (typeof func === 'function') {
-    try {
-      var cleanup = globalize()
-      return func()
-    } finally {
-      cleanup()
-    }
-  } else {
-    return globalize()
+module.exports = function globalJsdom (html, options) {
+  if (html === undefined) {
+    html = defaultHtml
   }
-}
 
-function globalize () {
+  if (options === undefined) {
+    options = {}
+  }
+
   // Idempotency
   if (global.navigator &&
     global.navigator.userAgent &&
@@ -35,7 +30,7 @@ function globalize () {
   }
 
   var jsdom = require('jsdom')
-  var document = jsdom.jsdom(html)
+  var document = jsdom.jsdom(html, options)
   var window = document.defaultView
   var keys = []
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/rstacruz/jsdom-global#readme",
   "devDependencies": {
     "jsdom": "7.2.2",
+    "standard": "^7.0.1",
     "tape": "4.4.0"
   }
 }


### PR DESCRIPTION
Pass the `options` to `jsdom.jsdom()` and offer the user the possibility to customize the `html` string.
I've added the `standard` package to the list of dev dependencies.

This should fix issue #3.
