### PR TITLE
Added `Image` to keys.js

### DIFF
--- a/keys.js
+++ b/keys.js
@@ -13,6 +13,7 @@ var LIVING_KEYS = [
   'DocumentType',
   'DOMImplementation',
   'ProcessingInstruction',
+  'Image',
   'Text',
   'Event',
   'CustomEvent',


### PR DESCRIPTION
I ran into an issue where programmatically creating an Image was causing tests to crash. I then noticed the `Image` constructor wasn't in your `keys.js`

Adding this resolved my issue.