### PR TITLE
Add jsdom instance reference to global

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports = function globalJsdom (html, options) {
     global[key] = window[key]
   })
 
+  global.jsdom = document
   global.document = window.document
   global.window = window
   window.console = global.console


### PR DESCRIPTION
Having a reference to jsdom will allow to access its API (see #26).