### PR TITLE
Add URLSearchParams to keys

### DIFF
--- a/keys.js
+++ b/keys.js
@@ -124,7 +124,8 @@ var LIVING_KEYS = [
   'XMLHttpRequestEventTarget',
   'XMLHttpRequestUpload',
   'DOMTokenList',
-  'URL'
+  'URL',
+  'URLSearchParams'
 ]
 
 var OTHER_KEYS = [


### PR DESCRIPTION
This is used by jsdom and was missing here https://github.com/tmpvar/jsdom/blob/master/lib/jsdom/living/index.js#L70.

Without this change you can't use fetch in your tests.