### PR TITLE
Make jsdom accessible as a global object

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ module.exports = function globalJsdom (html, options) {
 
   var jsdom = require('jsdom')
   var document = new jsdom.JSDOM(html, options)
+  global.jsdom = document;
   var window = document.window
 
   KEYS.forEach(function (key) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function globalJsdom (html, options) {
 
   var jsdom = require('jsdom')
   var document = new jsdom.JSDOM(html, options)
-  global.jsdom = document;
+  global.jsdom = document
   var window = document.window
 
   KEYS.forEach(function (key) {


### PR DESCRIPTION
Addresses #26 by adding the `jsdom` object as a global. This was necessary for me to use the `reconfigure()` method in tests.