### PR TITLE
feat: default url in register.js component preventing SecurityError

### DIFF
--- a/register.js
+++ b/register.js
@@ -1,1 +1,1 @@
-require('./index')()
+require('./index')(null, {url: 'https://localhost/'})


### PR DESCRIPTION
In our tests we are using **mocha** with **jsdom** and `import ... from ...`. There was no way how to enter a `url` to `register.js`. Since `register.js` is create a default jsdom-global object, I hope we could introduce a default url too so that we can get rid of this error:

> SecurityError: localStorage is not available for opaque origins